### PR TITLE
Fix host name limit

### DIFF
--- a/Client/Patchers/NameMenu.cs
+++ b/Client/Patchers/NameMenu.cs
@@ -1,0 +1,58 @@
+﻿using Archipelago.MonsterSanctuary.Client.AP;
+using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+using static SaveGameMenu;
+
+namespace Archipelago.MonsterSanctuary.Client
+{
+    public partial class Patcher
+    {
+        /// <summary>
+        /// Add new input type to max characters allowed check
+        /// </summary>
+        [HarmonyPatch(typeof(NameMenu), "MaxCharactersAllowed", MethodType.Getter)]
+        public static class NameMenu_MaxCharactersAllowed
+        {
+            public static bool Prefix(NameMenu __instance, ref int __result)
+            {
+                var nameType = (NameMenu.ENameType)Traverse.Create(UIController.Instance.NameMenu)
+                    .Field("nameType")
+                    .GetValue();
+                
+                __result = nameType == NameMenu.ENameType.MapMarker ? 20 : __instance.MaxCharacters;
+                __result = (int)nameType switch
+                {
+                    (int)NameMenu.ENameType.JoinCode => 4,
+                    (int)NameMenu.ENameType.SeedCode => 6,
+                    // check for our new input type of 7
+                    7 => __instance.MaxCharacters,
+                    _ => __result
+                };
+                return false;
+            }
+        }
+        
+        /// <summary>
+        /// Also disable confirmation if we're using the new input type
+        /// </summary>
+        [HarmonyPatch(typeof(NameMenu), "Confirm")]
+        public static class NameMenu_Confirm
+        {
+            public static bool Prefix(NameMenu __instance)
+            {
+                var nameType = (NameMenu.ENameType)Traverse.Create(UIController.Instance.NameMenu)
+                    .Field("nameType")
+                    .GetValue();
+                __instance.DirectKeyboardSupportHandler.Deactivate();
+                // If it's not the new menu type, just run the original code
+                if ((int)nameType != 7) return true;
+                AccessTools.Method(typeof(NameMenu), "ConfirmNaming")?.Invoke(__instance, []);
+                return false;
+            }
+        }
+    }
+}

--- a/Client/Patchers/TitleScreen.cs
+++ b/Client/Patchers/TitleScreen.cs
@@ -435,7 +435,7 @@ namespace Archipelago.MonsterSanctuary.Client
             var inputfield = Traverse.Create(UIController.Instance.NameMenu.DirectKeyboardSupportHandler)
                 .Field("InputField")
                 .GetValue() as MSInputField;
-            inputfield.characterLimit = 20;
+            inputfield.characterLimit = 21;
 
             string url = string.IsNullOrEmpty(host_name) ? "archipelago.gg:" : host_name;
 

--- a/Client/Patchers/TitleScreen.cs
+++ b/Client/Patchers/TitleScreen.cs
@@ -431,11 +431,10 @@ namespace Archipelago.MonsterSanctuary.Client
 
         private static void PromptToEnterArchipelagoUrl<T>(T __instance, Action<T> postConnectAction = null, Action<T> failedConnectionAction = null) where T : MonoBehaviour
         {
-            // Set the text limit for the NameMenus that pop up when entering data
-            var inputfield = Traverse.Create(UIController.Instance.NameMenu.DirectKeyboardSupportHandler)
-                .Field("InputField")
-                .GetValue() as MSInputField;
-            inputfield.characterLimit = 21;
+            // Setting to 21 here is sufficient for pasting, but you can't type due to the text mesh width check
+            // in NameMenu line 330. So it's better to set this to something outrageous than to deal with that.
+            UIController.Instance.NameMenu.MaxCharacters = 800;
+            UIController.Instance.NameMenu.MaxNameLength = 800;
 
             string url = string.IsNullOrEmpty(host_name) ? "archipelago.gg:" : host_name;
 
@@ -456,7 +455,7 @@ namespace Archipelago.MonsterSanctuary.Client
                     if (failedConnectionAction != null)
                         failedConnectionAction.Invoke(__instance);
                 },
-                NameMenu.ENameType.MapMarker));
+                (NameMenu.ENameType)7)); 
         }
 
         private static void PromptToEnterArchipelagoSlotName<T>(T __instance, Action<T> postConnectAction = null, Action<T> failedConnectionAction = null) where T : MonoBehaviour


### PR DESCRIPTION
Change character limit from 20 to ??? to account for 5 digit ports. 

Link to gif showing behavior: [https://cdn.discordapp.com/attachments/1096278752142577684/1360905769813278902/Monster_Sanctuary_AzXs4sv13G.gif?ex=67fcd1c3&is=67fb8043&hm=a946e7b4d6d1465817403f7bb497ffe7e9905e30dc7287fdbcaa1a8ba5874ede&](https://cdn.discordapp.com/attachments/1096278752142577684/1360905769813278902/Monster_Sanctuary_AzXs4sv13G.gif?ex=67fcd1c3&is=67fb8043&hm=a946e7b4d6d1465817403f7bb497ffe7e9905e30dc7287fdbcaa1a8ba5874ede&)

The text input has a goofy text mesh width check that prevents any kind of sane long values, so I set it to 800 and I'll just kinda hope that's good enough for all use cases. While the limit is technically 800 and you might be able to hit that with all "i"s, the real limit is lower because letter width varies and they have that goofy check in there that I don't want to mess with. You could probably get away with a prefix patch on the AppendCharacter method that's causing issues and, if we're in menu type 7, just allow the character and ignore limit entirely. BUT, I already went out of my way to learn Harmony for this and I'm afraid of side effects that I don't know of so I'll leave that as a further improvement.

Speaking of menu type 7, I added a new ENameType to handle this specific menu. Since, AFAIK, I can't actually update an enum via harmony (which makes sense) I've just dropped it in as menu type 7. It's only used for the hostname menu.

This is my first time touching harmony so please be extra critical. Thank you!